### PR TITLE
Change devforum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome to Roblox Avatar
 This repository contains our ever-growing library of tutorials, software templates, rigs, models, avatar assets and place files made available to our developer community to speed up your game development process using our latest avatar product features.
 
-Tell us what you think on the <a href="https://devforum.roblox.com/c/resources/71">DevForum - Resources</a>.
+Tell us what you think on the <a href="https://devforum.roblox.com/">Developer Forums</a>.
 
 Usage terms and conditions apply as described in the LICENSE.md file.
 


### PR DESCRIPTION
Original link directed to the Resources category, which is intended for posting user-created resources, not providing feedback on existing ones. I've modified the link to go to the broader developer forums as a whole since depending on the nature of the feedback the category it belongs in may differ.