### PR TITLE
Initial commit of Avatar Auto-Setup Demo code

### DIFF
--- a/AvatarAutoSetupDemo/README.md
+++ b/AvatarAutoSetupDemo/README.md
@@ -1,0 +1,10 @@
+# avatar-autosetup-demo
+A Demo Experience for the new AutoSetupAvatarAsync API in AvatarCreationService.
+
+The Workspace consists of 3 humanoid Models which each consist of a single MeshPart and SurfaceAppearance.
+Clicking on any of them will invoke the In-Experience Avatar Auto-Setup function.
+
+When it completes, the resulting avatar can be equipped by clicking on the pedestal again.
+
+Clicking once more on the currently equipped avatar pedestal will bring up the PromptCreateAvatarAsync dialog to upload
+the automatically setup avatar to the user's inventory.

--- a/AvatarAutoSetupDemo/default.project.json
+++ b/AvatarAutoSetupDemo/default.project.json
@@ -1,0 +1,28 @@
+{
+  "name": "avatar-autosetup-demo",
+  "tree": {
+    "$className": "DataModel",
+
+    "ReplicatedStorage": {
+      "$className": "ReplicatedStorage",
+      "$ignoreUnknownInstances": true,
+      "$path": "src/ReplicatedStorage"
+    },
+
+    "ServerScriptService": {
+      "$className": "ServerScriptService",
+      "$ignoreUnknownInstances": true,
+      "$path": "src/ServerScriptService"
+    },
+
+    "StarterPlayer": {
+      "$className": "StarterPlayer",
+      "StarterPlayerScripts": {
+        "$className": "StarterPlayerScripts",
+        "$ignoreUnknownInstances": true,
+        "$path": "src/StarterPlayerScripts"
+      },
+      "$ignoreUnknownInstances": true
+    }
+  }
+}

--- a/AvatarAutoSetupDemo/src/ReplicatedStorage/AvatarUtils.luau
+++ b/AvatarAutoSetupDemo/src/ReplicatedStorage/AvatarUtils.luau
@@ -12,6 +12,7 @@ local AvatarUtils = {}
 local tokenMap = {
 	[120412862677951] = "f40f3712-2e6e-4263-9d39-18efdf340fca",
 	[70760078093031] = "abcfb7e7-425f-4912-8e2f-baca98de6bc4",
+	[90515339563907] = "b15869c1-79ab-4260-a4f3-0a0ce6a73e72",
 }
 
 local TOKEN = tokenMap[game.PlaceId]

--- a/AvatarAutoSetupDemo/src/ReplicatedStorage/AvatarUtils.luau
+++ b/AvatarAutoSetupDemo/src/ReplicatedStorage/AvatarUtils.luau
@@ -16,8 +16,6 @@ local tokenMap = {
 
 local TOKEN = tokenMap[game.PlaceId]
 
-local DEBUG_IMPORT_PATH = nil -- "/Users/tcuadra/Downloads/autosetup.glb"
-
 -- Cache all humanoid descriptions that we fetch since they will be removed once
 -- fetched from both client and server.
 local cachedHumanoidDescriptions = {}
@@ -78,10 +76,6 @@ function AvatarUtils.equipAvatarOnClientById(generationId: string)
 end
 
 function AvatarUtils.setupAvatar(player: Player, inputModel: Model)
-	if DEBUG_IMPORT_PATH then
-		return AvatarCreationService:ImportAvatarAsync(player, DEBUG_IMPORT_PATH)
-	end
-
 	local model = inputModel:Clone()
 	EditableUtils.convertAllToEditables(model)
 	return AvatarCreationService:AutoSetupAvatarAsync(player, model)

--- a/AvatarAutoSetupDemo/src/ReplicatedStorage/AvatarUtils.luau
+++ b/AvatarAutoSetupDemo/src/ReplicatedStorage/AvatarUtils.luau
@@ -1,0 +1,106 @@
+-- Utilities for loading and equipping generated avatars.
+
+local AvatarCreationService = game:GetService("AvatarCreationService")
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+
+local EditableUtils = require(ReplicatedStorage:WaitForChild("EditableUtils"))
+local EquipAvatarEvent = ReplicatedStorage:WaitForChild("EquipAvatarEvent") :: RemoteEvent
+local AvatarUtils = {}
+
+local tokenMap = {
+	[120412862677951] = "f40f3712-2e6e-4263-9d39-18efdf340fca",
+	[70760078093031] = "abcfb7e7-425f-4912-8e2f-baca98de6bc4",
+}
+
+local TOKEN = tokenMap[game.PlaceId]
+
+local DEBUG_IMPORT_PATH = nil -- "/Users/tcuadra/Downloads/autosetup.glb"
+
+-- Cache all humanoid descriptions that we fetch since they will be removed once
+-- fetched from both client and server.
+local cachedHumanoidDescriptions = {}
+
+-- Wrapper around LoadGeneratedAvatarAsync to cache the results.
+local function loadGeneratedAvatar(generationId: string)
+	if cachedHumanoidDescriptions[generationId] then
+		return cachedHumanoidDescriptions[generationId]
+	end
+
+	local humanoidDescription = AvatarCreationService:LoadGeneratedAvatarAsync(generationId)
+	cachedHumanoidDescriptions[generationId] = humanoidDescription
+
+	return humanoidDescription
+end
+
+-- Manually equips the avatar on the client by replacing the current character model
+local function equipAvatarOnClient(newModel: Model)
+	local localPlayer = Players.LocalPlayer
+	local prevModel = localPlayer.Character
+	local newAnim = prevModel.Animate:Clone() -- Clone the existing animations
+	local name = prevModel.Name
+	local cframe = prevModel.PrimaryPart.CFrame
+
+	newModel.Parent = Workspace
+	newModel.Name = name
+	localPlayer.Character = newModel -- Set the new model as the local player character
+
+	-- Destroy the old Animate instance and add the new one as a child
+	local oldAnim = newModel:FindFirstChild("Animate")
+	if oldAnim then
+		oldAnim:Destroy()
+	end
+	newAnim.Parent = newModel
+
+	prevModel:Destroy()
+	newModel:PivotTo(cframe.Rotation + cframe.Position)
+
+	-- Update the camera to follow the new player model
+	local camera = Workspace.CurrentCamera
+	local cameraCFrame = camera.CFrame
+
+	-- Updating the camera subject causes the camera CFrame to change
+	local changedSignal
+	changedSignal = camera:GetPropertyChangedSignal("CFrame"):Connect(function()
+		-- Restore the original CFrame once it has changed
+		camera.CFrame = cameraCFrame
+		changedSignal:Disconnect()
+	end)
+
+	camera.CameraSubject = game.Players.LocalPlayer.Character
+end
+
+function AvatarUtils.equipAvatarOnClientById(generationId: string)
+	local humanoidDescription = loadGeneratedAvatar(generationId)
+	local model = Players:CreateHumanoidModelFromDescription(humanoidDescription, Enum.HumanoidRigType.R15)
+	equipAvatarOnClient(model)
+end
+
+function AvatarUtils.setupAvatar(player: Player, inputModel: Model)
+	if DEBUG_IMPORT_PATH then
+		return AvatarCreationService:ImportAvatarAsync(player, DEBUG_IMPORT_PATH)
+	end
+
+	local model = inputModel:Clone()
+	EditableUtils.convertAllToEditables(model)
+	return AvatarCreationService:AutoSetupAvatarAsync(player, model)
+end
+
+function AvatarUtils.publishAvatar(player:Player, generationId: string)
+	local humanoidDescription = loadGeneratedAvatar(generationId)
+
+	local success, errorMessage = pcall(function()
+		local result, bundleId, outfitId = AvatarCreationService:PromptCreateAvatarAsync(TOKEN, player, humanoidDescription)
+		print("publishAvatar result:", result, bundleId, outfitId)
+	end)
+	if not success then
+		warn("Failed to publish avatar:", errorMessage)
+	end
+end
+
+function AvatarUtils.equipAvatarFromServer(player: Player, generationId: string)
+	EquipAvatarEvent:FireClient(player, generationId)
+end
+
+return AvatarUtils

--- a/AvatarAutoSetupDemo/src/ReplicatedStorage/DemoModel.luau
+++ b/AvatarAutoSetupDemo/src/ReplicatedStorage/DemoModel.luau
@@ -1,0 +1,123 @@
+-- This class represents a humanoid model with the instance hierarchy
+-- described by the PedestalFolder type below.
+-- Creating a DemoModel instance around it allows it to handle clicks
+-- and manage the state of the avatar setup process for that model.
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local AvatarUtils = require(ReplicatedStorage:WaitForChild("AvatarUtils"))
+
+local STATE_INIT = "init" -- Initial state when the model is ready to be set up
+local STATE_INPROGRESS = "inprogress" -- State when avatar setup is in progress
+local STATE_EQUIP = "equip" -- State when avatar setup has completed successfully and the avatar is ready to equip
+local STATE_ERROR = "error" -- State when an error occurred during setup
+local STATE_PUBLISH = "publish" -- State when the avatar is already equipped and clicking will publish
+
+local DemoModel = {}
+DemoModel.__index = DemoModel
+
+type PedestalFolder = Folder & {
+    Model: Model,
+    Clicker: Folder & {
+        ClickDetector: ClickDetector,
+        SurfaceGui: SurfaceGui & {
+            TextLabel: TextLabel,
+        },
+    },
+}
+
+function DemoModel.new(pedestal: PedestalFolder, name: string?, onEquip: (demoModel: any) -> ())
+	local self = {}
+	setmetatable(self, DemoModel)
+
+	self.name = name
+	self.model = pedestal.Model
+	self.onEquip = onEquip
+	self.clickDetector = pedestal.Clicker.ClickDetector
+	self.textLabel = pedestal.Clicker.SurfaceGui.TextLabel
+	self.state = STATE_INIT
+	self.generationId = nil :: string?
+	self.connection = self.clickDetector.MouseClick:Connect(function(player)
+		self:onClicked(player)
+	end)
+
+	self:setState(STATE_INIT)
+
+	return self
+end
+
+function DemoModel:setText(text: string)
+	self.textLabel.Text = text
+end
+
+-- Update the clickable text based on the current state
+function DemoModel:updateText()
+	if self.state == STATE_INIT then
+		self:setText("Setup Avatar")
+	elseif self.state == STATE_INPROGRESS then
+		self:setText("In progress...")
+	elseif self.state == STATE_EQUIP then
+		self:setText("Equip")
+	elseif self.state == STATE_PUBLISH then
+		self:setText("Publish")
+	else
+		self:setText("Error. Retry")
+	end
+end
+
+-- Set the state and update the text label accordingly
+function DemoModel:setState(newState)
+	self.state = newState
+	self:updateText()
+end
+
+-- Invokes auto-setup and updates the state when it completes
+function DemoModel:doAutoSetup(player: Player)
+	self:setState(STATE_INPROGRESS)
+	task.spawn(function()
+		local success, errorMessage = pcall(function()
+			self.generationId = AvatarUtils.setupAvatar(player, self.model)
+		end)
+
+		if success then
+			self:setState(STATE_EQUIP)
+		else
+			self:setState(STATE_ERROR)
+			warn("AutoSetup failed:", errorMessage)
+		end
+	end)
+end
+
+-- Equip the auto-setup results for this model
+function DemoModel:doEquip(player: Player)
+	AvatarUtils.equipAvatarFromServer(player, self.generationId)
+	self:setState(STATE_PUBLISH)
+	self.onEquip(self)
+end
+
+-- Handle clicks on the model, based on the current state
+function DemoModel:onClicked(player)
+	if self.state == STATE_INIT or self.state == STATE_ERROR then
+		self:doAutoSetup(player)
+
+	elseif self.state == STATE_EQUIP then
+		self:doEquip(player)
+
+	elseif self.state == STATE_PUBLISH then
+		AvatarUtils.publishAvatar(player, self.generationId)
+	end
+end
+
+function DemoModel:destroy()
+	if self.connection then
+		self.connection:Disconnect()
+		self.connection = nil
+	end
+end
+
+function DemoModel:onUnequip()
+	if self.state == STATE_PUBLISH then
+		self:setState(STATE_EQUIP)
+	end
+end
+
+return DemoModel

--- a/AvatarAutoSetupDemo/src/ReplicatedStorage/EditableUtils.luau
+++ b/AvatarAutoSetupDemo/src/ReplicatedStorage/EditableUtils.luau
@@ -16,6 +16,7 @@ local function convertToEditableMesh(meshPart: MeshPart)
 			return
 		end
 		local newMesh = output
+		newMesh.TextureContent = meshPart.TextureContent
 		success, output = pcall(function()
 			meshPart:ApplyMesh(newMesh)
 		end)

--- a/AvatarAutoSetupDemo/src/ReplicatedStorage/EditableUtils.luau
+++ b/AvatarAutoSetupDemo/src/ReplicatedStorage/EditableUtils.luau
@@ -1,0 +1,66 @@
+-- Utility functions for converting assets to editable formats
+
+local AssetService = game:GetService("AssetService")
+
+local EditableUtils = {}
+
+-- Updates the content of a MeshPart to be an EditableMesh
+local function convertToEditableMesh(meshPart: MeshPart)
+	if meshPart.MeshContent and meshPart.MeshContent.SourceType == Enum.ContentSourceType.Uri then
+		local mesh = AssetService:CreateEditableMeshAsync(meshPart.MeshContent)
+		local content = Content.fromObject(mesh)
+		local success, output = pcall(function()
+			return AssetService:CreateMeshPartAsync(content)
+		end)
+		if not success then
+			return
+		end
+		local newMesh = output
+		success, output = pcall(function()
+			meshPart:ApplyMesh(newMesh)
+		end)
+		if not success then
+			warn("Failed to apply mesh:", output)
+		end
+	end
+end
+
+-- Converts texture Content to an EditableImage Content if it isn't already
+local function convertToEditableImageContent(content: Content): Content?
+	if not content then
+		return nil
+	end
+
+	if content.SourceType == Enum.ContentSourceType.Uri then
+		return Content.fromObject(AssetService:CreateEditableImageAsync(content))
+	elseif content.SourceType == Enum.ContentSourceType.Object then
+		return content
+	else
+		return nil
+	end
+end
+
+-- Converts all MeshParts and SurfaceAppearances in the given root Instance to editable formats.
+-- For now, the SurfaceAppearance is removed and its ColorMapContent is converted to EditableImage
+-- TextureContent on the MeshPart parent.
+function EditableUtils.convertAllToEditables(root: Instance)
+	for _, instance in root:GetDescendants() do
+		if instance:IsA("MeshPart") then
+			convertToEditableMesh(instance)
+			if instance.TextureContent and instance.TextureContent.SourceType == Enum.ContentSourceType.Uri then
+				instance.TextureContent = convertToEditableImageContent(instance.TextureContent)
+			end
+		elseif instance:IsA("SurfaceAppearance") then
+			if instance.Parent:IsA("MeshPart") then
+				if instance.ColorMapContent and instance.ColorMapContent.SourceType ~= Enum.ContentSourceType.None then
+					instance.Parent.TextureContent = convertToEditableImageContent(instance.ColorMapContent)
+				end
+			else
+				warn("SurfaceAppearance parent is not a MeshPart:", instance.Parent.ClassName, instance.Parent)
+			end
+			instance:Destroy()
+		end
+	end
+end
+
+return EditableUtils

--- a/AvatarAutoSetupDemo/src/ServerScriptService/ServerStart.server.luau
+++ b/AvatarAutoSetupDemo/src/ServerScriptService/ServerStart.server.luau
@@ -1,0 +1,25 @@
+-- Server-side initialization
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+
+local DemoModel = require(ReplicatedStorage:WaitForChild("DemoModel"))
+
+local lastEquippedDemoModel = nil
+
+-- Callback used to switch the last equipped DemoModel's action back to Equip
+-- when a different avatar model is equipped.
+local function onDemoModelEquip(equippedModel)
+	if lastEquippedDemoModel and lastEquippedDemoModel ~= equippedModel then
+		-- If there was a previously equipped model, invoke onUnequip on it
+		lastEquippedDemoModel:onUnequip()
+	end
+	lastEquippedDemoModel = equippedModel
+end
+
+-- Create DemoModel instances for each pedestal in the Workspace.
+-- They will connect to the ClickDetector and handle clicks
+-- (which will also keep the DemoModel instances alive).
+for _, pedestal in Workspace.Pedestals:GetChildren() do
+	DemoModel.new(pedestal, pedestal.Name, onDemoModelEquip)
+end

--- a/AvatarAutoSetupDemo/src/StarterPlayerScripts/ClientStart.client.luau
+++ b/AvatarAutoSetupDemo/src/StarterPlayerScripts/ClientStart.client.luau
@@ -1,0 +1,11 @@
+-- Client-side initialization
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local EquipAvatarEvent = ReplicatedStorage:WaitForChild("EquipAvatarEvent") :: RemoteEvent
+local AvatarUtils = require(ReplicatedStorage:WaitForChild("AvatarUtils"))
+
+-- Connect RemoteEvent on client to equip generated avatar model
+EquipAvatarEvent.OnClientEvent:Connect(function(generationId: string)
+	AvatarUtils.equipAvatarOnClientById(generationId)
+end)


### PR DESCRIPTION
### AI Summary

- Adds a demo in `AvatarCreationService` featuring three humanoid models to showcase `AutoSetupAvatarAsync` with interactive auto-setup, equip, and publish functionality.  
- Introduces `AvatarUtils` and `EditableUtils` for avatar management and asset editing, plus `DemoModel` to handle model state and user interactions.  
- Implements server (`ServerStart.server.luau`) and client (`ClientStart.client.luau`) scripts for demo initialization and avatar equip synchronization, accompanied by config and documentation files.

---
<sub>This PR summary is AI-generated. Verify the code changes, as errors may occur, and share feedback in [#code-center](https://rbx.enterprise.slack.com/archives/C053LPPLF6X).</sub>
<sub>Note: The AI summary covers objective PR changes. The author must verify accuracy and add business context such as purpose, testing, and rollout plans.</sub>

Is this PR summary helpful? :thumbsup: :thumbsdown: